### PR TITLE
Fix negative value clipping for upscalers

### DIFF
--- a/scripts/chainner_model.py
+++ b/scripts/chainner_model.py
@@ -98,7 +98,8 @@ class UpscalerChaiNNer(Upscaler):
             with torch.no_grad():
                 upscaled = pytorch_auto_split(img=np_img, model=model, device=devices.device, use_fp16=self.fp16, tiler=self.parse_tile_size_input(tile_size))
                 norm = 255.0 * torch.from_numpy(upscaled)
-                norm = 255.0 * (upscaled / upscaled.max()) # full range causes some color clipping
+                norm = torch.clamp(norm, min=0) # set negative value clipping to zero
+                norm = 255.0 * (norm / norm.max()) # full range causes some color clipping
                 img = PIL.Image.fromarray(np.uint8(norm))
                 # img = self.transform(upscaled)
         except Exception as e:

--- a/scripts/chainner_model.py
+++ b/scripts/chainner_model.py
@@ -97,11 +97,7 @@ class UpscalerChaiNNer(Upscaler):
         try:
             with torch.no_grad():
                 upscaled = pytorch_auto_split(img=np_img, model=model, device=devices.device, use_fp16=self.fp16, tiler=self.parse_tile_size_input(tile_size))
-                norm = 255.0 * torch.from_numpy(upscaled)
-                norm = torch.clamp(norm, min=0) # set negative value clipping to zero
-                norm = 255.0 * (norm / norm.max()) # full range causes some color clipping
-                img = PIL.Image.fromarray(np.uint8(norm))
-                # img = self.transform(upscaled)
+                img = PIL.Image.fromarray(np.uint8(upscaled, normalized=True))
         except Exception as e:
             log.error(f"Upscaler error: type={self.name} model={selected_model} error={e}")
         devices.torch_gc()


### PR DESCRIPTION
## Description

Addresses the clipping issue described in https://github.com/vladmandic/sd-extension-chainner/issues/6.

Only positive values were normalized before, not negative ones.

## Notes

**Offset approach**: Adding the absolute of the min-value (negative) to the whole tensor/image and then normalizing resulted in a grayish dull image. --> not used
**Clamping approach**: Best/proper results were achieved by just 'clamping' all negative clipping values to zero. --> implemented

## Before

![tmp43c8uocw](https://github.com/vladmandic/sd-extension-chainner/assets/74194322/87039238-0c2e-4ffb-91a9-1da24f74a1ee)

## After

![tmpdrsqc3tn](https://github.com/vladmandic/sd-extension-chainner/assets/74194322/ae162eb5-e1de-40fc-b72a-d3206f71a1b8)
